### PR TITLE
Include mne_qt_brower as dependency pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
   "pte-stats",
   "scikit-image",
   "scipy",
+  "mne_qt_browser",
+  "pyqt5"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I really like the `pipeline` module @richardkoehler! Worked right out of the box except adding a tiny dependency.

`raw.plot` won't work without installing `pyqt5` and `mne_qt_browser` first.

https://github.com/richardkoehler/pte/blob/50616c59bdf1698710b7328c4059d297b80d2dae/src/pte/pipelines/pipelines.py#L25
